### PR TITLE
Confirm merge from privateToPublicToPrivate-pr2-working to privateToPublicToPrivate-pr2 to sync with https://github.com/OPS-E2E-Prod/E2E_RepoSync_Private_Public (branch privateToPublicToPrivate-pr2)

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -18,6 +18,7 @@
   "notification_subscribers": [],
   "sync_notification_subscribers": [],
   "branches_to_filter": [],
+  "git_repository_url_open_to_public_contributors": "https://github.com/OPS-E2E-Prod/E2E_RepoSync_Public_Public",
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,
   "contribution_branch_mappings": {},
@@ -31,6 +32,7 @@
   ],
   "branch_target_mapping": {},
   "need_generate_pdf_url_template": false,
+  "targets": {},
   "docs_build_engine": {
     "name": "docfx_v3"
   }


### PR DESCRIPTION
Pull request opened by Docs to confirm syncing from https://github.com/OPS-E2E-Prod/E2E_RepoSync_Private_Public (branch privateToPublicToPrivate-pr2).